### PR TITLE
Enhance Pickle Compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 env
 *egg-info
 .cache
+*.swp

--- a/siren_client/__init__.py
+++ b/siren_client/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.0.dev1'
+__version__ = '1.0.1'
 
 
 from .client import SirenClient

--- a/siren_client/client.py
+++ b/siren_client/client.py
@@ -6,6 +6,7 @@ DEFAULT_CONFIG = {
     'loads': None,
     'dumps': None,
     'self_rel': 'self',
+    'raise_for_status': True,
 }
 
 
@@ -29,7 +30,8 @@ class SirenClient(object):
 
         request = getattr(self.session, method)
         response = request(url, **kwargs)
-        response.raise_for_status()
+        if self.config['raise_for_status']:
+            response.raise_for_status()
         return self.loads(response.headers.get('content-type', None),
                           response.content)
 

--- a/siren_client/client.py
+++ b/siren_client/client.py
@@ -10,12 +10,17 @@ DEFAULT_CONFIG = {
 
 
 class SirenClient(object):
+
     def __init__(self, session, config=None):
         self.config = {}
         self.config.update(DEFAULT_CONFIG)
         if config is not None:
             self.config.update(config)
         self.session = session
+
+    def __getstate__(self):
+        '''Prevent any accidental pickling of this object'''
+        raise ValueError, 'SirenClient should not be pickled'
 
     def request(self, url, method='get', **kwargs):
         if 'data' in kwargs:

--- a/siren_client/entity.py
+++ b/siren_client/entity.py
@@ -11,7 +11,7 @@ class SirenObject(object):
         '''Ensure that client does not get pickled'''
         state = self.__dict__.copy()
         if 'client' in state:
-            del state['client']
+            state['client'] = None
         return state
 
 
@@ -31,6 +31,10 @@ class SirenActions(SirenObject, dict):
             value = SirenAction(self.client, dict.__getitem__(self, item))
             self[item] = value
         return value
+
+    def items(self):
+        return [(key,self[key]) for key in self]
+
 
 
 class SirenEntities(SirenObject, list):
@@ -61,6 +65,9 @@ class SirenLinks(SirenObject, dict):
     def __getitem__(self, item):
         uri = dict.__getitem__(self, item)
         return self.client.follow(uri)
+
+    def items(self):
+        return [(key,self[key]) for key in self]
 
 
 class SirenAction(SirenObject):


### PR DESCRIPTION
Siren Entities should be pickle-able. To enable this the 'client' is excluded when an entity is being pickled. When an entity is un-pickled, a client should be re-attached for any web requests.